### PR TITLE
Fix build matrix exclude combination

### DIFF
--- a/.github/workflows/c2a-build.yml
+++ b/.github/workflows/c2a-build.yml
@@ -62,7 +62,7 @@ jobs:
         compiler: [gcc, clang]
         warning: [Werror, Wextra]
         exclude:
-          - compiler: gcc
+          - compiler: clang
             warning: Werror
 
     steps:


### PR DESCRIPTION
- exclude したいのは clang でかつ `-Werror` の場合だったが，誤って gcc かつ `-Werror` の場合になっていた
  - これは，一部の C89 な C2A user において，一部の warning の無効化が clang ではできないことによるもの
  - 正確には，厳密な C89 ではなく C89 + 一部の C99 言語機能，なターゲットが存在する
- それはそれとして，一部であっても warning を見逃す行為は optional とすべき
  - こちらはバグ修正ではなく minor update となるので，この PR とは別で行う