### PR TITLE
Split c2a-build Win32 job impl into composite action

### DIFF
--- a/.github/workflows/c2a-build-test.yml
+++ b/.github/workflows/c2a-build-test.yml
@@ -31,7 +31,6 @@ jobs:
           ./setup.sh
         fi
       cmake_generator_linux32: Ninja
-      cmake_generator_win32: Ninja
       cmake_flags_linux32: -DUSE_SCI_COM_WINGS=OFF
       sils_mockup: true
       build_as_cxx: true

--- a/.github/workflows/c2a-build.yml
+++ b/.github/workflows/c2a-build.yml
@@ -248,46 +248,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        if: inputs.c2a_dir == '.'
+
+      - uses: ./action-c2a-build-win32
         with:
-          path: ./c2a_user
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - uses: actions/checkout@v3
-        if: inputs.c2a_dir != '.'
-        with:
-          path: ./repo
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - name: Link C2A user dir to ./c2a_user
-        working-directory: .
-        if: inputs.c2a_dir != '.'
-        shell: cmd
-        run: mklink /j /d ".\\c2a_user" ".\\repo\\${{ inputs.c2a_dir }}"
-
-      - name: Check setup script exist
-        id: check_setup
-        continue-on-error: true
-        shell: bash
-        run: test -f setup.bat
-
-      - name: Setup
-        if: steps.check_setup.outcome == 'success'
-        shell: cmd
-        run: ./setup.bat
-
-      - name: Custom Setup
-        if: inputs.c2a_custom_setup != ''
-        shell: bash
-        run: ${{ inputs.c2a_custom_setup }}
-
-      - name: CMake
-        shell: bash
-        run: |
-          cmake -B ./build \
-            -G "${{ inputs.cmake_generator_win32 }}" \
-            -DBUILD_C2A_AS_CXX=ON \
-            ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_win32_cxx }}
-
-      - name: Build
-        run: cmake --build ./build
+          c2a_repo: ${{ inputs.c2a_repo }}
+          c2a_dir: ${{ inputs.c2a_dir }}
+          c2a_custom_setup: ${{ inputs.c2a_custom_setup }}
+          build_as_cxx: true
+          cmake_generator: ${{ inputs.cmake_generator_win32 }}
+          cmake_flags: ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_win32_cxx }}

--- a/.github/workflows/c2a-build.yml
+++ b/.github/workflows/c2a-build.yml
@@ -198,48 +198,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        if: inputs.c2a_dir == '.'
+
+      - uses: ./action-c2a-build-win32
         with:
-          path: ./c2a_user
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - uses: actions/checkout@v3
-        if: inputs.c2a_dir != '.'
-        with:
-          path: ./repo
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - name: Link C2A user dir to ./c2a_user
-        working-directory: .
-        if: inputs.c2a_dir != '.'
-        shell: cmd
-        run: mklink /j /d ".\\c2a_user" ".\\repo\\${{ inputs.c2a_dir }}"
-
-      - name: Check setup script exist
-        id: check_setup
-        continue-on-error: true
-        shell: bash
-        run: test -f setup.bat
-
-      - name: Setup
-        if: steps.check_setup.outcome == 'success'
-        shell: cmd
-        run: ./setup.bat
-
-      - name: Custom Setup
-        if: inputs.c2a_custom_setup != ''
-        shell: bash
-        run: ${{ inputs.c2a_custom_setup }}
-
-      - name: CMake
-        shell: bash
-        run: |
-          cmake -B ./build \
-            -G "${{ inputs.cmake_generator_win32 }}" \
-            ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_win32 }}
-
-      - name: Build
-        run: cmake --build ./build
+          c2a_repo: ${{ inputs.c2a_repo }}
+          c2a_dir: ${{ inputs.c2a_dir }}
+          c2a_custom_setup: ${{ inputs.c2a_custom_setup }}
+          cmake_generator: ${{ inputs.cmake_generator_win32 }}
+          cmake_flags: ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_win32 }}
 
   build_win32_cxx:
     if: inputs.build_as_cxx

--- a/action-c2a-build-win32/action.yml
+++ b/action-c2a-build-win32/action.yml
@@ -47,20 +47,24 @@ runs:
     - name: Check setup script exist
       id: check_setup
       continue-on-error: true
+      working-directory: ./c2a_user
       shell: bash
       run: test -f setup.bat
 
     - name: Setup
       if: steps.check_setup.outcome == 'success'
+      working-directory: ./c2a_user
       shell: cmd
       run: ./setup.bat
 
     - name: Custom Setup
       if: inputs.c2a_custom_setup != ''
+      working-directory: ./c2a_user
       shell: bash
       run: ${{ inputs.c2a_custom_setup }}
 
     - name: CMake
+      working-directory: ./c2a_user
       shell: bash
       run: |
         cmake -B ./build \
@@ -69,6 +73,7 @@ runs:
 
     - name: CMake as C++
       if: inputs.build_as_cxx
+      working-directory: ./c2a_user
       shell: bash
       run: |
         cmake -B ./build \
@@ -77,5 +82,6 @@ runs:
           ${{ inputs.cmake_flags }}
 
     - name: Build
+      working-directory: ./c2a_user
       shell: bash
       run: cmake --build ./build

--- a/action-c2a-build-win32/action.yml
+++ b/action-c2a-build-win32/action.yml
@@ -1,0 +1,81 @@
+name: build-c2a-win32
+description: Build C2A user on Win32 by MSVC/MSVC++
+
+author: '@sksat'
+
+inputs:
+  c2a_repo:
+    type: string
+    default: ${{ github.repository }}
+  c2a_dir:
+    type: string
+    default: '.'
+  c2a_custom_setup:
+    type: string
+    default: ''
+  build_as_cxx:
+    type: boolean
+    default: true
+  cmake_generator:
+    type: string
+    default: 'Visual Studio 17 2022'
+  cmake_flags:
+    type: string
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+      if: inputs.c2a_dir == '.'
+      with:
+        path: ./c2a_user
+        repository: ${{ inputs.c2a_repo }}
+        submodules: 'recursive'
+    - uses: actions/checkout@v3
+      if: inputs.c2a_dir != '.'
+      with:
+        path: ./repo
+        repository: ${{ inputs.c2a_repo }}
+        submodules: 'recursive'
+    - name: Link C2A user dir to ./c2a_user
+      working-directory: .
+      if: inputs.c2a_dir != '.'
+      shell: cmd
+      run: mklink /j /d ".\\c2a_user" ".\\repo\\${{ inputs.c2a_dir }}"
+
+    - name: Check setup script exist
+      id: check_setup
+      continue-on-error: true
+      shell: bash
+      run: test -f setup.bat
+
+    - name: Setup
+      if: steps.check_setup.outcome == 'success'
+      shell: cmd
+      run: ./setup.bat
+
+    - name: Custom Setup
+      if: inputs.c2a_custom_setup != ''
+      shell: bash
+      run: ${{ inputs.c2a_custom_setup }}
+
+    - name: CMake
+      shell: bash
+      run: |
+        cmake -B ./build \
+          -G "${{ inputs.cmake_generator }}" \
+          ${{ inputs.cmake_flags }}
+
+    - name: CMake as C++
+      if: inputs.build_as_cxx
+      shell: bash
+      run: |
+        cmake -B ./build \
+          -G "${{ inputs.cmake_generator }}" \
+          -DBUILD_C2A_AS_CXX=ON \
+          ${{ inputs.cmake_flags }}
+
+    - name: Build
+      shell: bash
+      run: cmake --build ./build

--- a/action-c2a-build-win32/action.yml
+++ b/action-c2a-build-win32/action.yml
@@ -64,6 +64,7 @@ runs:
       run: ${{ inputs.c2a_custom_setup }}
 
     - name: CMake
+      if: inputs.build_as_cxx == 'false'
       working-directory: ./c2a_user
       shell: bash
       run: |
@@ -72,7 +73,7 @@ runs:
           ${{ inputs.cmake_flags }}
 
     - name: CMake as C++
-      if: inputs.build_as_cxx
+      if: inputs.build_as_cxx == 'true'
       working-directory: ./c2a_user
       shell: bash
       run: |

--- a/action-c2a-build-win32/action.yml
+++ b/action-c2a-build-win32/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: ''
   build_as_cxx:
     type: boolean
-    default: true
+    default: false
   cmake_generator:
     type: string
     default: 'Visual Studio 17 2022'


### PR DESCRIPTION
- `c2a-build` の Win32 でのビルド手順は build as C++ かどうかのみの差しかなく，inputs も少ないので，実装を composite action にまとめる
- この composite action を単体で使ってもよいが，あくまでリリース単位は `c2a-build` workflow のままとする