### PR TITLE
Split c2a-build job impl into composite action

### DIFF
--- a/.github/workflows/c2a-build.yml
+++ b/.github/workflows/c2a-build.yml
@@ -80,15 +80,9 @@ jobs:
             ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_linux32 }} \
             -DADD_WEXTRA_FLAGS=${{ contains(matrix.warning, 'Wextra') }} \
             -DADD_WERROR_FLAGS=${{ contains(matrix.warning, 'Werror') }}
-
-      - name: reviewdog with clang-tidy -${{ matrix.warning }}
-        if: matrix.compiler == 'clang'
-        uses: arkedge/action-clang-tidy@v1.0.0
-        with:
-          tool_name: clang-tidy -${{ matrix.warning }}
-          reporter: ${{ (!contains(matrix.warning, 'Wextra') && inputs.reviewdog_default_reporter ) || 'github-check' }}
-          filter_mode: ${{ (!contains(matrix.warning, 'Wextra') && inputs.reviewdog_default_filter ) || 'nofilter' }}
-          workdir: ./c2a_user/build
+          reviewdog_tool_name: clang-tidy -${{ matrix.warning }}
+          reviewdog_reporter: ${{ (!contains(matrix.warning, 'Wextra') && inputs.reviewdog_default_reporter ) || 'github-check' }}
+          reviewdog_filter_mode: ${{ (!contains(matrix.warning, 'Wextra') && inputs.reviewdog_default_filter ) || 'nofilter' }}
 
   build_linux32_cxx:
     if: inputs.build_as_cxx

--- a/.github/workflows/c2a-build.yml
+++ b/.github/workflows/c2a-build.yml
@@ -67,53 +67,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        if: inputs.c2a_dir == '.'
-        with:
-          path: ./c2a_user
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - uses: actions/checkout@v3
-        if: inputs.c2a_dir != '.'
-        with:
-          path: ./repo
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - name: Link C2A user dir to ./c2a_user
-        working-directory: .
-        if: inputs.c2a_dir != '.'
-        run: ln -s ./repo/${{ inputs.c2a_dir }} ./c2a_user
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build libc6-dev-i386
-
-      - name: Check setup script exist
-        id: check_setup
-        continue-on-error: true
-        shell: bash
-        run: test -f setup.sh
-
-      - name: Setup
-        if: steps.check_setup.outcome == 'success'
-        run: ./setup.sh
-
-      - name: Custom Setup
-        if: inputs.c2a_custom_setup != ''
-        shell: bash
-        run: ${{ inputs.c2a_custom_setup }}
-
-      - name: CMake
+      - uses: ./action-c2a-build
         env:
           CC: ${{ matrix.compiler }}
-        run: |
-          cmake -B ./build \
-            -G "${{ inputs.cmake_generator_linux32 }}" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DADD_WEXTRA_FLAGS=${{ contains(matrix.warning, 'Wextra') }} \
-            -DADD_WERROR_FLAGS=${{ contains(matrix.warning, 'Werror') }} \
-            ${{ (inputs.sils_mockup && '-DUSE_SILS_MOCKUP=ON') || '' }} \
+        with:
+          c2a_repo: ${{ inputs.c2a_repo }}
+          c2a_dir: ${{ inputs.c2a_dir }}
+          c2a_custom_setup: ${{ inputs.c2a_custom_setup }}
+          cmake_generator: ${{ inputs.cmake_generator_linux32 }}
+          cmake_flags: |
             ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_linux32 }}
+            -DADD_WEXTRA_FLAGS=${{ contains(matrix.warning, 'Wextra') }}
+            -DADD_WERROR_FLAGS=${{ contains(matrix.warning, 'Werror') }}
 
       - name: reviewdog with clang-tidy -${{ matrix.warning }}
         if: matrix.compiler == 'clang'
@@ -123,15 +89,6 @@ jobs:
           reporter: ${{ (!contains(matrix.warning, 'Wextra') && inputs.reviewdog_default_reporter ) || 'github-check' }}
           filter_mode: ${{ (!contains(matrix.warning, 'Wextra') && inputs.reviewdog_default_filter ) || 'nofilter' }}
           workdir: ./c2a_user/build
-
-      - name: Build
-        run: cmake --build ./build
-
-      - name: Run executable by SILS mockup
-        if: inputs.sils_mockup
-        run: |
-          ls -lh ./build/C2A
-          timeout 3 ./build/C2A || exit 0
 
   build_linux32_cxx:
     if: inputs.build_as_cxx

--- a/.github/workflows/c2a-build.yml
+++ b/.github/workflows/c2a-build.yml
@@ -140,57 +140,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        if: inputs.c2a_dir == '.'
+
+      - uses: ./action-c2a-build
         with:
-          path: ./c2a_user
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - uses: actions/checkout@v3
-        if: inputs.c2a_dir != '.'
-        with:
-          path: ./repo
-          repository: ${{ inputs.c2a_repo }}
-          submodules: 'recursive'
-      - name: Link C2A user dir to ./c2a_user
-        working-directory: .
-        if: inputs.c2a_dir != '.'
-        run: ln -s ./repo/${{ inputs.c2a_dir }} ./c2a_user
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build libc6-dev-i386 g++-multilib
-
-      - name: Check setup script exist
-        id: check_setup
-        continue-on-error: true
-        shell: bash
-        run: test -f setup.sh
-
-      - name: Setup
-        if: steps.check_setup.outcome == 'success'
-        run: ./setup.sh
-
-      - name: Custom Setup
-        if: inputs.c2a_custom_setup != ''
-        shell: bash
-        run: ${{ inputs.c2a_custom_setup }}
-
-      - name: CMake
-        env:
-          CC: clang
-          CXX: clang++
-        # ignore windows.h
-        run: |
-          cmake -B ./build \
-            -G "${{ inputs.cmake_generator_linux32 }}" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DBUILD_C2A_AS_CXX=ON \
-            -DUSE_SCI_COM_WINGS=OFF \
-            ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_linux32_cxx }}
-
-      - name: Build
-        run: cmake --build ./build
+          c2a_repo: ${{ inputs.c2a_repo }}
+          c2a_dir: ${{ inputs.c2a_dir }}
+          c2a_custom_setup: ${{ inputs.c2a_custom_setup }}
+          build_as_cxx: true
+          cmake_generator: ${{ inputs.cmake_generator_linux32 }}
+          cmake_flags: ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_linux32 }}
 
   build_win32:
     name: Build for Win32 by MSVC

--- a/.github/workflows/c2a-build.yml
+++ b/.github/workflows/c2a-build.yml
@@ -77,8 +77,8 @@ jobs:
           c2a_custom_setup: ${{ inputs.c2a_custom_setup }}
           cmake_generator: ${{ inputs.cmake_generator_linux32 }}
           cmake_flags: |
-            ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_linux32 }}
-            -DADD_WEXTRA_FLAGS=${{ contains(matrix.warning, 'Wextra') }}
+            ${{ inputs.cmake_flags }} ${{ inputs.cmake_flags_linux32 }} \
+            -DADD_WEXTRA_FLAGS=${{ contains(matrix.warning, 'Wextra') }} \
             -DADD_WERROR_FLAGS=${{ contains(matrix.warning, 'Werror') }}
 
       - name: reviewdog with clang-tidy -${{ matrix.warning }}

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: ''
   sils_mockup:
     type: boolean
-    default: true
+    default: false
   build_as_cxx:
     type: boolean
     default: false

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -1,0 +1,82 @@
+name: build-c2a
+description: Build C2A user
+
+author: '@sksat'
+
+inputs:
+  c2a_repo:
+    type: string
+    default: ${{ github.repository }}
+  c2a_dir:
+    type: string
+    default: '.'
+  c2a_custom_setup:
+    type: string
+    default: ''
+  build_as_cxx:
+    type: boolean
+    default: false
+  cmake_generator:
+    type: string
+    default: 'Unix Makefiles'
+  cmake_flags:
+    type: string
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+      if: inputs.c2a_dir == '.'
+    - uses: actions/checkout@v3
+      if: inputs.c2a_dir == '.'
+      with:
+        path: ./c2a_user
+        repository: ${{ inputs.c2a_repo }}
+        submodules: 'recursive'
+    - uses: actions/checkout@v3
+      if: inputs.c2a_dir != '.'
+      with:
+        path: ./repo
+        repository: ${{ inputs.c2a_repo }}
+        submodules: 'recursive'
+    - name: Link C2A user dir to ./c2a_user
+      working-directory: .
+      if: inputs.c2a_dir != '.'
+      run: ln -s ./repo/${{ inputs.c2a_dir }} ./c2a_user
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build libc6-dev-i386 g++-multilib
+
+    - name: Check setup script exist
+      id: check_setup
+      continue-on-error: true
+      shell: bash
+      run: test -f setup.sh
+
+    - name: Setup
+      if: steps.check_setup.outcome == 'success'
+      run: ./setup.sh
+
+    - name: Custom Setup
+      if: inputs.c2a_custom_setup != ''
+      shell: bash
+      run: ${{ inputs.c2a_custom_setup }}
+
+    - name: CMake
+      env:
+        CC: clang
+        CXX: clang++
+      # ignore windows.h
+      run: |
+        cmake -B ./build \
+          -G "${{ inputs.cmake_generator }}" \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -DBUILD_C2A_AS_CXX=ON \
+          -DUSE_SCI_COM_WINGS=OFF \
+          ${{ inputs.cmake_flags }}
+
+    - name: Build
+      run: cmake --build ./build

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -25,6 +25,16 @@ inputs:
   cmake_flags:
     type: string
     default: ''
+  # reviewdog
+  reviewdog_tool_name:
+    type: string
+    default: clang-tidy
+  reviewdog_reporter:
+    type: string
+    default: github-pr-review
+  reviewdog_filter_mode:
+    type: string
+    default: added
 
 runs:
   using: "composite"
@@ -113,3 +123,12 @@ runs:
       run: |
         ls -lh ./build/C2A
         timeout 3 ./build/C2A || exit 0
+
+    - name: reviewdog with clang-tidy -${{ matrix.warning }}
+      if: env.CC == 'clang'
+      uses: arkedge/action-clang-tidy@v1.0.0
+      with:
+        tool_name: ${{ inputs.reviewdog_tool_name }}
+        reporter: ${{ inputs.reviewdog_reporter }}
+        filter_mode: ${{ inputs.reviewdog_filter_mode }}
+        workdir: ./c2a_user/build

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -95,7 +95,7 @@ runs:
       run: cmake --build ./build
 
     - name: Run executable by SILS mockup
-      if: inputs.sils_mockup
+      if: inputs.sils_mockup == 'true'
       working-directory: ./c2a_user
       shell: bash
       run: |

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -43,9 +43,11 @@ runs:
     - name: Link C2A user dir to ./c2a_user
       working-directory: .
       if: inputs.c2a_dir != '.'
+      shell: bash
       run: ln -s ./repo/${{ inputs.c2a_dir }} ./c2a_user
 
     - name: Install dependencies
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y ninja-build libc6-dev-i386 g++-multilib
@@ -58,6 +60,7 @@ runs:
 
     - name: Setup
       if: steps.check_setup.outcome == 'success'
+      shell: bash
       run: ./setup.sh
 
     - name: Custom Setup
@@ -69,6 +72,7 @@ runs:
       env:
         CC: clang
         CXX: clang++
+      shell: bash
       # ignore windows.h
       run: |
         cmake -B ./build \
@@ -79,4 +83,5 @@ runs:
           ${{ inputs.cmake_flags }}
 
     - name: Build
+      shell: bash
       run: cmake --build ./build

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -13,6 +13,9 @@ inputs:
   c2a_custom_setup:
     type: string
     default: ''
+  sils_mockup:
+    type: boolean
+    default: true
   build_as_cxx:
     type: boolean
     default: false
@@ -90,3 +93,11 @@ runs:
       working-directory: ./c2a_user
       shell: bash
       run: cmake --build ./build
+
+    - name: Run executable by SILS mockup
+      if: inputs.sils_mockup
+      working-directory: ./c2a_user
+      shell: bash
+      run: |
+        ls -lh ./build/C2A
+        timeout 3 ./build/C2A || exit 0

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -55,16 +55,19 @@ runs:
     - name: Check setup script exist
       id: check_setup
       continue-on-error: true
+      working-directory: ./c2a_user
       shell: bash
       run: test -f setup.sh
 
     - name: Setup
       if: steps.check_setup.outcome == 'success'
+      working-directory: ./c2a_user
       shell: bash
       run: ./setup.sh
 
     - name: Custom Setup
       if: inputs.c2a_custom_setup != ''
+      working-directory: ./c2a_user
       shell: bash
       run: ${{ inputs.c2a_custom_setup }}
 
@@ -72,6 +75,7 @@ runs:
       env:
         CC: clang
         CXX: clang++
+      working-directory: ./c2a_user
       shell: bash
       # ignore windows.h
       run: |
@@ -83,5 +87,6 @@ runs:
           ${{ inputs.cmake_flags }}
 
     - name: Build
+      working-directory: ./c2a_user
       shell: bash
       run: cmake --build ./build

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -75,6 +75,18 @@ runs:
       run: ${{ inputs.c2a_custom_setup }}
 
     - name: CMake
+      if: inputs.build_as_cxx == 'false'
+      working-directory: ./c2a_user
+      shell: bash
+      run: |
+        cmake -B ./build \
+          -G "${{ inputs.cmake_generator }}" \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          ${{ (inputs.sils_mockup && '-DUSE_SILS_MOCKUP=ON') || '' }} \
+          ${{ inputs.cmake_flags }}
+
+    - name: CMake as C++
+      if: inputs.build_as_cxx == 'true'
       env:
         CC: clang
         CXX: clang++


### PR DESCRIPTION
- #5 と同様に，linux32 の job についても `action-c2a-build` に実装を分割する