### PR TITLE
パターンとして `%C` を追加

### DIFF
--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -72,6 +72,7 @@ jobs:
             -reporter=github-pr-review \
             -efm="%-GThe above files are invalid coding rule." \
             -efm="%E%f: %l: %m" \
+            -efm="%C" \
             -efm="%Z%s" \
             < /tmp/coding-rule.log
 


### PR DESCRIPTION
## 概要

```plaintext
./hoge.c: 1: EMPTY-LINED ERROR MESSAGE 

./hoge.h: 10: ERROR MESSAGE
fuga
```

みたいなログを reviewdog に食わせた際に，前半 `2` 行をスルーさせないための対策．

## 関連 Issue

- Resolve: https://github.com/arkedge/pj-c2a/issues/84

## 確認方法

https://reviewdog.github.io/errorformat-playground/ で確認．

上記のログを突っ込んだ状態で，パターンを次のようにスイッチ:

- Before:
    ```plaintext
    %E%f: %l: %m
    %Z%s
    ```
- After:
    ```plaintext
    %E%f: %l: %m
    %C
    %Z%s
    ```

## 参考

- https://vim-jp.org/vimdoc-en/quickfix.html#errorformat-multi-line

`%C` は continuation of a multi-line message を意味する．