### PR TITLE
Force OFF BUILD_C2A_AS_CXX to treat default C++ C2A user

### DIFF
--- a/action-c2a-build-win32/action.yml
+++ b/action-c2a-build-win32/action.yml
@@ -45,6 +45,7 @@ runs:
       run: |
         cmake -B ./build \
           -G "${{ inputs.cmake_generator }}" \
+          -DBUILD_C2A_AS_CXX=OFF \
           ${{ inputs.cmake_flags }}
 
     - name: CMake as C++

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -65,6 +65,7 @@ runs:
         cmake -B ./build \
           -G "${{ inputs.cmake_generator }}" \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -DBUILD_C2A_AS_CXX=OFF \
           ${{ (inputs.sils_mockup && '-DUSE_SILS_MOCKUP=ON') || '' }} \
           ${{ inputs.cmake_flags }}
 


### PR DESCRIPTION
この workflow を CMake で全体的に C++ としてビルドするような一部の C2A user 環境で動かすことを想定できていなかったので，Cとしてビルドする step では明示的に OFF にする．

`BUILD_C2A_AS_CXX` が default ON になっているような環境は現在では非推奨ではあるものの，非自明なエラーを出さないための処置．