### PR TITLE
check-coding-rule: Auto switch coding rule config

### DIFF
--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -56,6 +56,7 @@ jobs:
         shell: bash
         env:
           CONFIG_FILE: ${{ inputs.config_file }}
+        working-directory: ${{ inputs.c2a_dir }}/src
         run: |
           if [ -e "$CONFIG_FILE" ]; then
             echo "config_file=${CONFIG_FILE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -21,6 +21,7 @@ on:
         default: src_user/Script/CI/check_coding_rule.json
 
 env:
+  CORE_CONFIG_FILE: src_core/Script/CI/check_coding_rule.json
   check_script: ./src_core/Script/CI/check_coding_rule.py
 
 jobs:
@@ -50,13 +51,28 @@ jobs:
         shell: bash
         run: ${{ inputs.c2a_custom_setup }}
 
+      - name: check config file
+        id: config
+        shell: bash
+        env:
+          CONFIG_FILE: ${{ inputs.config_file }}
+        run: |
+          if [ -e "$CONFIG_FILE" ]; then
+            echo "config_file=${CONFIG_FILE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "${CONFIG_FILE} does not exist"
+            echo "fallback to c2a-core config file"
+
+            echo "config_file=${CORE_CONFIG_FILE}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: check coding rule
         id: check
         shell: bash -e {0}
         continue-on-error: true
         working-directory: ${{ inputs.c2a_dir }}/src
         run: |
-          python ${{ env.check_script }} ${{ inputs.config_file }} | tee /tmp/coding-rule.log
+          python ${{ env.check_script }} ${{ steps.config.outputs.config_file }} | tee /tmp/coding-rule.log
           status="${PIPESTATUS[0]}"
           echo "status: ${status}"
           echo "status=${status}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -18,7 +18,7 @@ on:
       config_file:
         type: string
         description: check_coding_rule config file(relative path from <C2A user>/src)
-        default: src_core/Script/CI/check_coding_rule.json
+        default: src_user/Script/CI/check_coding_rule.json
 
 env:
   check_script: ./src_core/Script/CI/check_coding_rule.py


### PR DESCRIPTION
- Resolve #38 
- breaking change なため，v3 でのリリースとする
- デフォルトでは user 部の設定ファイルを使うように変更
  - スクリプトそのもののリファクタをしたとしても，user 毎に ignore rule を追加したりすることは想定できるため
- user 部の設定ファイルが存在しなかった場合は core の設定に fallback する
- user 専用の設定ファイルがある C2A user でも default workflow を使用可能にすることが主目的