### PR TITLE
Add c2a_dir switch input to default workflow

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -6,6 +6,9 @@ on:
       federation_repos:
         type: string
         default: ""
+      c2a_dir:
+        type: string
+        default: .
 
 jobs:
   build:
@@ -13,15 +16,18 @@ jobs:
     secrets: inherit
     with:
       federation_repos: ${{ inputs.federation_repos }}
+      c2a_dir: ${{ inputs.c2a_dir }}
 
   check_coding_rule:
     secrets: inherit
     uses: ./.github/workflows/check-coding-rule.yml
     with:
       federation_repos: ${{ inputs.federation_repos }}
+      c2a_dir: ${{ inputs.c2a_dir }}
 
   check_encoding:
     secrets: inherit
     uses: ./.github/workflows/check-encoding.yml
     with:
       federation_repos: ${{ inputs.federation_repos }}
+      c2a_dir: ${{ inputs.c2a_dir }}


### PR DESCRIPTION
- C2A user のディレクトリを指定するオプションを default workflow の input にも追加
- これは C2A user の monorepo（c2a-core Examples 含む） での default workflow の使用を意図したもの