### PR TITLE
Insert update-config-file phase

### DIFF
--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -67,6 +67,14 @@ jobs:
             echo "config_file=${CORE_CONFIG_FILE}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: update config file
+        uses: jossef/action-set-json-field@7ea163261afe43847c06afab44419845339a6be2
+        with:
+          # FIXME: Dirty
+          file: ${{ inputs.c2a_dir }}/src/${{ steps.config.outputs.config_file }}
+          field: "c2a_root_dir"
+          value: ${{ github.workspace }}
+
       - name: check coding rule
         id: check
         shell: bash -e {0}


### PR DESCRIPTION
## 概要

https://github.com/jossef/action-set-json-field を用いて `check_coding_rule.json` のフィールド `c2a_root_dir` を実行時コンテキストにおけるリポジトリルートの絶対パスに書き換える．

- `check_coding_rule.json` はフォールバックされる場合フォールバック後の（つまり c2a-core 側の）が，されない場合は c2a-user 側のものがそれぞれ使用される
- したがって，c2a-user 側の `check_coding_rule.json` において `target_dirs` を（上記の前提に基づいて）正しく設定することが求められる

要するにこれは運用の固定であって単なる機能の追加ではなく `c2a_root_dir` を `repository_root_dir` として利用することを強制するものである．

## 備考

- c2a-core および個別 c2a-user の開発時における手元 linting に関するドキュメントが必要
- 一時的な対応にとどまる可能性あり，最終的には `src_user` と `src_core` の相対パスだけ指定，とかそういう風にしたい．