### PR TITLE
v4: Standardize check-coding-script execute path to script dir

### DIFF
--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -94,7 +94,8 @@ jobs:
 
       - name: fix error log source file path
         run: |
-          sed -i 's ./src_user ${{ inputs.c2a_dir }}/src/src_user g' /tmp/coding-rule.log
+          C2A_SRC_DIR="$(cat ${{ inputs.c2a_dir }}/src/${{ steps.config.outputs.config_file }} | jq -r .c2a_root_dir)"
+          sed -i "s ${C2A_SRC_DIR} ${{ inputs.c2a_dir }}/src/ g" /tmp/coding-rule.log
           cat /tmp/coding-rule.log
 
       - name: reviewdog(github-pr-review)

--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -21,6 +21,7 @@ on:
         default: src_user/Script/CI/check_coding_rule.json
 
 env:
+  # 設定ファイルなどのパスは <c2a-user>/src からの相対パス（TODO: c2a-user top からの相対パスにする）
   CORE_CONFIG_FILE: src_core/Script/CI/check_coding_rule.json
   check_script: ./src_core/Script/CI/check_coding_rule.py
 
@@ -73,7 +74,10 @@ jobs:
         continue-on-error: true
         working-directory: ${{ inputs.c2a_dir }}/src
         run: |
-          python ${{ env.check_script }} ${{ steps.config.outputs.config_file }} | tee /tmp/coding-rule.log
+          C2A_SRC_DIR="$(pwd)"
+          # このスクリプトはスクリプトと同じディレクトリで実行されることが多い（この workflow では一旦それを標準化する）
+          cd "$(dirname ${{ env.check_script }})"
+          python "$(basename ${{ env.check_script }})" "${C2A_SRC_DIR}/${{ steps.config.outputs.config_file }}" | tee /tmp/coding-rule.log
           status="${PIPESTATUS[0]}"
           echo "status: ${status}"
           echo "status=${status}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 経緯

- c2a-core の `check_coding_rule.py` は以下のようにスクリプトがあるディレクトリで実行されることが多い
  - `src/src_core/Script/CI>python ./check_coding_rule.py ../../../src_user/Script/CI/check_coding_rule.json`
- これはあくまでも AE 及び ut-issl に存在する C2A user の実態を確認したらそのパターンが**多かったというだけ**であり，そうでなければならないというわけではない
- 実際，workflows-c2a の `check-coding-rule` を整備した際には，そうではない設定ファイルが用いられている C2A user をターゲットに動作確認を行っていた
- その後，workflows-c2a を各 C2A user に撒いた結果，設定とこの実装が乖離することが多くなってしまった
- この問題の根本的な原因以下
  - `check_coding_rule.py` の挙動が実行位置に強く依存している
  - `check_coding_rule.py` が正しく実行されていない場合であっても，それに気付くことができない（エラーを出さない）
  - `check_coding_rule.json` の `c2a_root_dir` がほとんどの場合 **C2A user top dir ではなく** `<c2a-user>/src` を指していて非常に confusing
  - `check_coding_rule.json` の `c2a_root_dir` は `check_coding_rule.py` の実行位置（多くの場合 `<c2a-user>/src/src_core/Script/CI`）からの相対パスであり，非常に confusing

## 概要
- 根本的な原因は c2a-core problem であり，仮に修正したところで一度に撒くことはできない
- `check_coding_rule.py` をスクリプトがあるディレクトリで実行する，という現状よくある手順を標準化する
- この具体的な（渋い）手順を残し続けるつもりは無いが，workflows-c2a を導入しているのであれば手段が共通化されているはず，という状態を実現することが目的

## 補足
- 一部の `check_coding_rule.py` の実行位置が異なる想定の C2A user に対しては breaking change