### PR TITLE
Add check-coding-rule config dirs existence

### DIFF
--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -68,6 +68,19 @@ jobs:
             echo "config_file=${CORE_CONFIG_FILE}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: check config dirs
+        run: |
+          C2A_SRC_DIR="$(jq -r .c2a_root_dir < ${{ inputs.c2a_dir }}/src/${{ steps.config.outputs.config_file }})"
+          TARGET_DIRS="$(jq -r .target_dirs[] < ${{ inputs.c2a_dir }}/src/${{ steps.config.outputs.config_file }})"
+          echo ".c2a_root_dir: ${C2A_SRC_DIR}"
+          echo ".target_dirs: ${TARGET_DIRS}"
+          cd "${{ inputs.c2a_dir }}/src/$(dirname ${{ env.check_script }})"
+          echo "${TARGET_DIRS}" | while read -r target_dir; do
+            echo "target_dir: ${target_dir}"
+            ls "${C2A_SRC_DIR}/${target_dir}"
+            echo ""
+          done
+
       - name: check coding rule
         id: check
         shell: bash -e {0}


### PR DESCRIPTION
- #54 の根本原因の一つである，`check_coding_rule.py` が正しく実行されていない場合であっても，それに気付くことができない（エラーを出さない）を解決する
- `c2a_root_dir` および `target_dirs` を正しく考慮して `target_dirs` のディレクトリが存在するか確認する
- 本来この確認は `check_coding_rule.py` が行うべきものだが，c2a-core で改修を行っても即座にそれを各 C2A user に適用することができないため，暫定的に workflows-c2a 側でチェックする