### PR TITLE
Support c2a-core v4 C++ build option

### DIFF
--- a/action-c2a-build-win32/action.yml
+++ b/action-c2a-build-win32/action.yml
@@ -59,6 +59,7 @@ runs:
         cmake -B ./build \
           -G "${{ inputs.cmake_generator }}" \
           -DBUILD_C2A_AS_CXX=OFF \
+          -DC2A_BUILD_AS_CXX=OFF \
           ${{ inputs.cmake_flags }}
 
     - name: CMake as C++
@@ -69,6 +70,7 @@ runs:
         cmake -B ./build \
           -G "${{ inputs.cmake_generator }}" \
           -DBUILD_C2A_AS_CXX=ON \
+          -DC2A_BUILD_AS_CXX=ON \
           ${{ inputs.cmake_flags }}
 
     - name: Build

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -79,6 +79,7 @@ runs:
           -G "${{ inputs.cmake_generator }}" \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DBUILD_C2A_AS_CXX=OFF \
+          -DC2A_BUILD_AS_CXX=OFF \
           ${{ (inputs.sils_mockup && '-DUSE_SILS_MOCKUP=ON') || '' }} \
           ${{ inputs.cmake_flags }}
 
@@ -95,6 +96,7 @@ runs:
           -G "${{ inputs.cmake_generator }}" \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DBUILD_C2A_AS_CXX=ON \
+          -DC2A_BUILD_AS_CXX=ON \
           -DUSE_SCI_COM_WINGS=OFF \
           ${{ inputs.cmake_flags }}
 


### PR DESCRIPTION
- 本 workflow のビルド手順が根本的に変わるようなことがあった場合は c2a-core の major update を行うようにしていきたい
  - これはつまり同時に複数の c2a-core major version をサポートする必要が発生しうるということでもある
  - 実際，現状でも v3 系と v4 系を同時にサポートする必要がある
- c2a-core v4 の一環として，CMake option を整理している: https://github.com/arkedge/c2a-core/pull/86
- ここで，本 workflow が用いている `BUILD_AS_CXX` option が `C2A_BUILD_AS_CXX` に変わる
- c2a-core major version での処理の切り替えの方法にはいくつか手段があり，それは #60 で検討する
- それはそれとして，今回の CMake option の変更については影響があるのは単なる rename である上に，存在しなくなった option を指定してもビルドはできる（CMake の warning は出る）ため，一旦同時に新旧両方の option を指定することで簡易的に v3, v4 の両サポートを行う