### PR TITLE
Add check-coding-rule workflow for c2a-core v4

### DIFF
--- a/.github/workflows/check-coding-rule-v4.yml
+++ b/.github/workflows/check-coding-rule-v4.yml
@@ -1,0 +1,91 @@
+name: check coding rule
+
+on:
+  workflow_call:
+    inputs:
+      federation_repos:
+        type: string
+        default: ""
+      c2a_dir:
+        type: string
+        default: '.'
+      c2a_custom_setup:
+        type: string
+        default: ''
+      c2a_core:
+        type: boolean
+        default: false
+
+env:
+  # <c2a-user> からの相対パス
+  config_file: ./check_coding_rule.json
+  check_script: ./src_core/script/ci/check_coding_rule.py
+
+jobs:
+  check_coding_rule:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: gh-federation
+        if: inputs.federation_repos != ''
+        uses: arkedge/gh-federation@437d2b0433a7d4a009e311d176d18abd85626fa4 # v3.1.0
+        with:
+          endpoint: ${{ secrets.GH_FEDERATION_ENDPOINT }}
+          repos: ${{ inputs.federation_repos }}
+
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+        with:
+          python-version-file: .github/workflows/.python-version
+          architecture: 'x64'
+
+      - name: Custom Setup
+        if: inputs.c2a_custom_setup != ''
+        working-directory: ${{ inputs.c2a_dir }}
+        shell: bash
+        run: ${{ inputs.c2a_custom_setup }}
+
+      - name: check coding rule
+        id: check
+        shell: bash -e {0}
+        continue-on-error: true
+        run: |
+          python ${{ inputs.c2a_dir }}/${{ env.check_script }} ${{ inputs.c2a_dir }}/${{ env.config_file }} | tee /tmp/coding-rule.log
+          status="${PIPESTATUS[0]}"
+          echo "status: ${status}"
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          exit "${status}"
+
+      - name: install reviewdog
+        uses: reviewdog/action-setup@80a06617492b461a66508e2dedf16233f0506804 # v1.0.6
+
+      - name: fix error log source file path for c2a-core
+        if: inputs.c2a_core == 'true'
+        run: |
+          sed -i 's#${{ inputs.c2a_dir }}/src/src_core/##g' /tmp/coding-rule.log
+          cat /tmp/coding-rule.log
+
+      - name: reviewdog(github-pr-review)
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          reviewdog \
+            -name 'check_coding_rule' \
+            -level error \
+            -fail-on-error=true \
+            -filter-mode=added \
+            -diff="git diff FETCH_HEAD" \
+            -reporter=github-pr-review \
+            -efm="%-GThe above files are invalid coding rule." \
+            -efm="%E%f: %l: %m" \
+            -efm="%C" \
+            -efm="%Z%s" \
+            < /tmp/coding-rule.log
+
+      - name: exit
+        shell: bash
+        run: |
+          exit $(( "${{ steps.check.outputs.status }}" ))

--- a/.github/workflows/check-coding-rule-v4.yml
+++ b/.github/workflows/check-coding-rule-v4.yml
@@ -19,7 +19,7 @@ on:
 env:
   # <c2a-user> からの相対パス
   config_file: ./check_coding_rule.json
-  check_script: ./src_core/script/ci/check_coding_rule.py
+  check_script: ./src/src_core/script/ci/check_coding_rule.py
 
 jobs:
   check_coding_rule:


### PR DESCRIPTION
- c2a-core v4 向けの check-coding-rule の workflow を（既存のものとは別に）追加します
- https://github.com/arkedge/c2a-core/pull/97 への対応が主な目的です