### PR TITLE
Support c2a-core v4 SILS mockup build option

### DIFF
--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -80,7 +80,7 @@ runs:
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DBUILD_C2A_AS_CXX=OFF \
           -DC2A_BUILD_AS_CXX=OFF \
-          ${{ (inputs.sils_mockup && '-DUSE_SILS_MOCKUP=ON') || '' }} \
+          ${{ (inputs.sils_mockup && '-DUSE_SILS_MOCKUP=ON' '-DC2A_BUILD_WITH_SILS_MOCKUP=ON') || '' }} \
           ${{ inputs.cmake_flags }}
 
     - name: CMake as C++


### PR DESCRIPTION
#61 と同様の理由で，https://github.com/arkedge/c2a-core/pull/132 で SILS mockup のオプションが変わるので，一旦追加で指定するようにする