### PR TITLE
 Support c2a-core v4 SCI_COM build option 

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,7 +27,7 @@ jobs:
           ./setup.sh
         fi
       cmake_generator_linux32: Ninja
-      cmake_flags_linux32: -DUSE_SCI_COM_WINGS=OFF
+      cmake_flags_linux32: -DUSE_SCI_COM_WINGS=OFF -DC2A_USE_SCI_COM_WINGS=OFF
       sils_mockup: true
       build_as_cxx: true
       reviewdog_default_reporter: github-check

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -97,7 +97,7 @@ runs:
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DBUILD_C2A_AS_CXX=ON \
           -DC2A_BUILD_AS_CXX=ON \
-          -DUSE_SCI_COM_WINGS=OFF \
+          -DUSE_SCI_COM_WINGS=OFF -DC2A_USE_SCI_COM_WINGS=OFF \
           ${{ inputs.cmake_flags }}
 
     - name: Build


### PR DESCRIPTION
#61, #68 と同様の理由で，https://github.com/arkedge/c2a-core/pull/132 で SCI_COM 系のオプションが変わるので，一旦追加で指定するようにする