### PR TITLE
Change Build as C++ job to optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
         default: true
       build_as_cxx:
         type: boolean
-        default: true
+        default: false
       cmake_generator_linux32:
         type: string
         default: 'Unix Makefiles'

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -9,6 +9,9 @@ on:
       c2a_dir:
         type: string
         default: .
+      build_as_cxx:
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -17,6 +20,7 @@ jobs:
     with:
       federation_repos: ${{ inputs.federation_repos }}
       c2a_dir: ${{ inputs.c2a_dir }}
+      build_as_cxx: ${{ inputs.build_as_cxx }}
 
   check_coding_rule:
     secrets: inherit


### PR DESCRIPTION
- Resolve #44 
- Breaking Change
- 基本的にC言語で書かれた C2A を C++ でビルドするのはイレギュラーな対応であり，またサポートも困難であるため，デフォルト挙動では Build as C++ job が発火しないようにする
- 一方で，SILS-S2E などにおいて，現状 C++ として C2A をビルドしているケースは存在はするため，workflows-c2a v5 系ではこの挙動はオプションとして残す（default workflow を含む）
  - なお，これらのケースについてもほとんどの場合は消極的な理由によるものなはずであるため，C++ としてビルドする事態は今後できるだけ排除していく方針