### PR TITLE
Lock reviewdog version & rollback reviewdog to 0.16 for mitigate error in test

### DIFF
--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -117,6 +117,7 @@ runs:
       if: env.CC == 'clang'
       uses: arkedge/action-clang-tidy@8faddab26ad258e389cef75916414df15c3a9544 # v1.5.0
       with:
+        reviewdog_version: v0.16.0
         tool_name: ${{ inputs.reviewdog_tool_name }}
         reporter: ${{ inputs.reviewdog_reporter }}
         filter_mode: ${{ inputs.reviewdog_filter_mode }}


### PR DESCRIPTION
SSIA