### PR TITLE
Explicitly set gh-federation endpoint as GitHub Actions secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build
 
 on:
   workflow_call:
-    secrets:
-      GH_FEDERATION_ENDPOINT:
-        required: false
     inputs:
       c2a_repo:
         type: string
@@ -59,6 +56,9 @@ on:
       reviewdog_default_filter:
         type: string
         default: added
+    secrets:
+      GH_FEDERATION_ENDPOINT:
+        required: false
 
 env:
   SELF_VERSION: v5.1.0

--- a/.github/workflows/check-coding-rule-v3.yml
+++ b/.github/workflows/check-coding-rule-v3.yml
@@ -22,6 +22,9 @@ on:
       reviewdog_version:
         type: string
         default: latest
+    secrets:
+      GH_FEDERATION_ENDPOINT:
+        required: false
 
 env:
   # 設定ファイルなどのパスは <c2a-user>/src からの相対パス（TODO: c2a-user top からの相対パスにする）

--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -18,6 +18,9 @@ on:
       reviewdog_version:
         type: string
         default: latest
+    secrets:
+      GH_FEDERATION_ENDPOINT:
+        required: false
 
 env:
   # <c2a-user> からの相対パス

--- a/.github/workflows/check-encoding-v3.yml
+++ b/.github/workflows/check-encoding-v3.yml
@@ -12,6 +12,9 @@ on:
       c2a_core:
         type: boolean
         default: false
+    secrets:
+      GH_FEDERATION_ENDPOINT:
+        required: false
 
 env:
   # config file path from src/src_core/Script/CI

--- a/.github/workflows/check-encoding.yml
+++ b/.github/workflows/check-encoding.yml
@@ -12,6 +12,9 @@ on:
       c2a_core:
         type: boolean
         default: false
+    secrets:
+      GH_FEDERATION_ENDPOINT:
+        required: false
 
 env:
   # config file path from src/src_core/Script/CI

--- a/.github/workflows/default-v3.yml
+++ b/.github/workflows/default-v3.yml
@@ -18,6 +18,9 @@ on:
       reviewdog_version:
         type: string
         default: v0.16.0
+    secrets:
+      GH_FEDERATION_ENDPOINT:
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,6 +18,9 @@ on:
       reviewdog_version:
         type: string
         default: v0.16.0
+    secrets:
+      GH_FEDERATION_ENDPOINT:
+        required: false
 
 jobs:
   build:


### PR DESCRIPTION
- reusable workflow では使用する secret は使う側で定義していなければならない
- これは same organization なら省略できる
- 動くので省略してしまっていたが，これでは別 organization から workflow-c2a の reusable workflow を使う時に gh-federation が動作しないという問題があった