### PR TITLE
Make build SILS mockup optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
         default: ''
       sils_mockup:
         type: boolean
-        default: true
+        default: false
       build_msvc:
         type: boolean
         default: false


### PR DESCRIPTION
- SILS mockup は無の c2a-runtime で、executable をビルドすることでリンカのエラーを適切に出すためのもの
- しかし、これは事実上 c2a-core でしか使っていないので、optional にする
- default workflow にはオプションの追加はしない