### PR TITLE
Feat: fix chardet version for check-encoding

### DIFF
--- a/.github/workflows/check-encoding-v3.yml
+++ b/.github/workflows/check-encoding-v3.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Checkout workflows-c2a for dependency lockfile
-        run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
+        run: git clone --depth 1 -b feature/update-encoding https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
 
       - name: Install dependencies
         run: uv sync --project /tmp/workflows-c2a --no-dev

--- a/.github/workflows/check-encoding-v3.yml
+++ b/.github/workflows/check-encoding-v3.yml
@@ -41,7 +41,13 @@ jobs:
           python-version-file: .github/workflows/.python-version
           architecture: 'x64'
 
-      - run: pip install chardet
+      - uses: astral-sh/setup-uv@5a095e7a6bfc5cbace3fa00e5cbc1e4afe6a3ad0 # v7.3.1
+
+      - name: Checkout workflows-c2a for dependency lockfile
+        run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
+
+      - name: Install dependencies
+        run: uv sync --project /tmp/workflows-c2a --no-dev
 
       - name: check config file
         id: config
@@ -60,8 +66,8 @@ jobs:
       - name: check_encoding for c2a-core
         if: inputs.c2a_core
         working-directory: ./Script/CI
-        run: python ./check_encoding.py ./check_encoding.json
+        run: uv run --project /tmp/workflows-c2a python ./check_encoding.py ./check_encoding.json
       - name: check_encoding
         if: ${{ ! inputs.c2a_core }}
         working-directory: ${{ inputs.c2a_dir }}/src/src_core/Script/CI
-        run: python ./check_encoding.py ${{ steps.config.outputs.config_file }}
+        run: uv run --project /tmp/workflows-c2a python ./check_encoding.py ${{ steps.config.outputs.config_file }}

--- a/.github/workflows/check-encoding-v3.yml
+++ b/.github/workflows/check-encoding-v3.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Checkout workflows-c2a for dependency lockfile
-        run: git clone --depth 1 -b feature/update-encoding https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
+        run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
 
       - name: Install dependencies
         run: uv sync --project /tmp/workflows-c2a --no-dev

--- a/.github/workflows/check-encoding-v3.yml
+++ b/.github/workflows/check-encoding-v3.yml
@@ -41,7 +41,7 @@ jobs:
           python-version-file: .github/workflows/.python-version
           architecture: 'x64'
 
-      - uses: astral-sh/setup-uv@5a095e7a6bfc5cbace3fa00e5cbc1e4afe6a3ad0 # v7.3.1
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Checkout workflows-c2a for dependency lockfile
         run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a

--- a/.github/workflows/check-encoding.yml
+++ b/.github/workflows/check-encoding.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Checkout workflows-c2a for dependency lockfile
-        run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
+        run: git clone --depth 1 -b feature/update-encoding https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
 
       - name: Install dependencies
         run: uv sync --project /tmp/workflows-c2a --no-dev

--- a/.github/workflows/check-encoding.yml
+++ b/.github/workflows/check-encoding.yml
@@ -41,7 +41,13 @@ jobs:
           python-version-file: .github/workflows/.python-version
           architecture: 'x64'
 
-      - run: pip install chardet
+      - uses: astral-sh/setup-uv@5a095e7a6bfc5cbace3fa00e5cbc1e4afe6a3ad0 # v7.3.1
+
+      - name: Checkout workflows-c2a for dependency lockfile
+        run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
+
+      - name: Install dependencies
+        run: uv sync --project /tmp/workflows-c2a --no-dev
 
       - name: check config file
         id: config
@@ -60,8 +66,8 @@ jobs:
       - name: check_encoding for c2a-core
         if: inputs.c2a_core
         working-directory: ./script/ci
-        run: python ./check_encoding.py ./check_encoding.json
+        run: uv run --project /tmp/workflows-c2a python ./check_encoding.py ./check_encoding.json
       - name: check_encoding
         if: ${{ ! inputs.c2a_core }}
         working-directory: ${{ inputs.c2a_dir }}/src/src_core/script/ci
-        run: python ./check_encoding.py ${{ steps.config.outputs.config_file }}
+        run: uv run --project /tmp/workflows-c2a python ./check_encoding.py ${{ steps.config.outputs.config_file }}

--- a/.github/workflows/check-encoding.yml
+++ b/.github/workflows/check-encoding.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Checkout workflows-c2a for dependency lockfile
-        run: git clone --depth 1 -b feature/update-encoding https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
+        run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a
 
       - name: Install dependencies
         run: uv sync --project /tmp/workflows-c2a --no-dev

--- a/.github/workflows/check-encoding.yml
+++ b/.github/workflows/check-encoding.yml
@@ -41,7 +41,7 @@ jobs:
           python-version-file: .github/workflows/.python-version
           architecture: 'x64'
 
-      - uses: astral-sh/setup-uv@5a095e7a6bfc5cbace3fa00e5cbc1e4afe6a3ad0 # v7.3.1
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Checkout workflows-c2a for dependency lockfile
         run: git clone --depth 1 https://github.com/arkedge/workflows-c2a.git /tmp/workflows-c2a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "workflows-c2a"
+version = "0.0.0"
+requires-python = ">=3.8"
+dependencies = [
+    "chardet>=5,<7",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,43 @@
+version = 1
+revision = 1
+requires-python = ">=3.8"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
+]
+
+[[package]]
+name = "chardet"
+version = "6.0.0.post1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/42/fb9436c103a881a377e34b9f58d77b5f503461c702ff654ebe86151bcfe9/chardet-6.0.0.post1.tar.gz", hash = "sha256:6b78048c3c97c7b2ed1fbad7a18f76f5a6547f7d34dbab536cc13887c9a92fa4", size = 12521798 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/42/5de54f632c2de53cd3415b3703383d5fff43a94cbc0567ef362515261a21/chardet-6.0.0.post1-py3-none-any.whl", hash = "sha256:c894a36800549adf7bb5f2af47033281b75fdfcd2aa0f0243be0ad22a52e2dcb", size = 627245 },
+]
+
+[[package]]
+name = "workflows-c2a"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "chardet", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "chardet", version = "6.0.0.post1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "chardet", specifier = ">=5,<7" }]


### PR DESCRIPTION
chardet 7.0.0 がリリースされたことで check_encoding ジョブのCIが落ちるようになったので、uv.lockにてchardetのバージョンを固定するように変更