### PR TITLE
Pin reviewdog version everywhere & make it Renovate-trackable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ on:
       # reviewdog
       reviewdog_version:
         type: string
+        # renovate: datasource=github-releases depName=reviewdog/reviewdog
         default: v0.16.0
       reviewdog_default_reporter:
         type: string

--- a/.github/workflows/check-coding-rule-v3.yml
+++ b/.github/workflows/check-coding-rule-v3.yml
@@ -21,7 +21,8 @@ on:
         default: src_user/Script/CI/check_coding_rule.json
       reviewdog_version:
         type: string
-        default: latest
+        # renovate: datasource=github-releases depName=reviewdog/reviewdog
+        default: v0.16.0
     secrets:
       GH_FEDERATION_ENDPOINT:
         required: false

--- a/.github/workflows/check-coding-rule.yml
+++ b/.github/workflows/check-coding-rule.yml
@@ -17,7 +17,8 @@ on:
         default: false
       reviewdog_version:
         type: string
-        default: latest
+        # renovate: datasource=github-releases depName=reviewdog/reviewdog
+        default: v0.16.0
     secrets:
       GH_FEDERATION_ENDPOINT:
         required: false

--- a/.github/workflows/default-v3.yml
+++ b/.github/workflows/default-v3.yml
@@ -21,6 +21,7 @@ on:
         default: false
       reviewdog_version:
         type: string
+        # renovate: datasource=github-releases depName=reviewdog/reviewdog
         default: v0.16.0
     secrets:
       GH_FEDERATION_ENDPOINT:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -21,6 +21,7 @@ on:
         default: false
       reviewdog_version:
         type: string
+        # renovate: datasource=github-releases depName=reviewdog/reviewdog
         default: v0.16.0
     secrets:
       GH_FEDERATION_ENDPOINT:

--- a/action-c2a-build/action.yml
+++ b/action-c2a-build/action.yml
@@ -34,7 +34,8 @@ inputs:
   # reviewdog
   reviewdog_version:
     type: string
-    default: latest
+    # renovate: datasource=github-releases depName=reviewdog/reviewdog
+    default: v0.16.0
   reviewdog_tool_name:
     type: string
     default: clang-tidy

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,18 @@
     "helpers:pinGitHubActionDigests"
   ],
   "additionalReviewers": ["sksat"],
-  "assignees": ["sksat"]
+  "assignees": ["sksat"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track reviewdog version pinned in reusable workflow / composite action input defaults",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/",
+        "/^action-[^/]+/action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)\\s+default:\\s*(?<currentValue>\\S+)"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## What

`reviewdog_version` の default が2種類に分かれていたのを `v0.16.0` に統一し、Renovate の追跡対象に入れます。

| ファイル | before | after |
|---|---|---|
| `action-c2a-build/action.yml` | `latest` | `v0.16.0` |
| `.github/workflows/check-coding-rule.yml` | `latest` | `v0.16.0` |
| `.github/workflows/check-coding-rule-v3.yml` | `latest` | `v0.16.0` |
| `.github/workflows/build.yml` | `v0.16.0` | `v0.16.0`（マーカー追加のみ） |
| `.github/workflows/default.yml` | `v0.16.0` | `v0.16.0`（マーカー追加のみ） |
| `.github/workflows/default-v3.yml` | `v0.16.0` | `v0.16.0`（マーカー追加のみ） |

## Why

v0.16.0 への pin は reviewdog 更新による CI エラーの緩和策として `e97a2b6` で入りましたが、その19分後の `91ee258` が `action.yml` のハードコード値を `default: latest` な input に置き換えたため、**pin が reusable workflow 経由の呼び出しにしか効かない状態**になっていました。`action-c2a-build` や `check-coding-rule.yml` を直接呼ぶと reviewdog は `latest` に浮いたままです。

さらに `reviewdog_version` は単なる input の default 文字列なので、`config:base` も `helpers:pinGitHubActionDigests` も認識できません。そのため約1年半のあいだ bump PR が一度も来ず、更新が止まっていることに気づけない状態でした。

## Renovate 対応

`# renovate:` マーカーと regex customManager を追加し、今後の bump が**6箇所まとめて1本の Renovate PR** になるようにしました。

検証済み:
- regex が対象6箇所すべてにマッチ（`datasource=github-releases`, `depName=reviewdog/reviewdog`, `currentValue=v0.16.0`）
- マーカーなしで残った `reviewdog_version` の default は 0 件
- `renovate-config-validator` … exit 0 / `Config validated successfully`
- `managerFilePatterns` を使用（`fileMatch` は Renovate 41 で deprecated。このリポジトリは hosted app = 常に最新 Renovate）

## Notes

- `check-coding-rule` は `-reporter=github-pr-review` を使っており、reviewdog v0.19.0 の `-fail-on-error` 挙動変更（`github-[pr-]check` 限定）の影響を受けません。使用しているフラグの範囲では v0.16.0 への pin は挙動を変えません
- **この PR の後、Renovate が v0.16.0 → v0.21.0 の bump PR を出してきます。** それは即マージしないでください。v0.19.0 の breaking change により、`build.yml` の Wextra レーン（`github-check` + `nofilter`）が warning で CI を落とすようになります。先に `-fail-level` 対応（`arkedge/action-clang-tidy` への `fail_level` input 追加）が必要です
- `renovate.json` には `WARN: Config migration necessary`（`config:base` → `config:recommended`）が既存で出ていますが、この PR の scope 外としてそのままにしています

🤖 Generated with [Claude Code](https://claude.com/claude-code)