### PR TITLE
Migrate renovate preset config:base to config:recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
   "additionalReviewers": ["sksat"],


### PR DESCRIPTION
## What

`renovate.json` の `extends` を `config:base` → `config:recommended` に変更します。1行のみ。

## Why

`config:base` は Renovate 36 で `config:recommended` に改名され、現在は deprecated な alias です。そのため `renovate-config-validator` が

```
 WARN: Config migration necessary
 INFO: Config validated successfully
```

を出しており、hosted Renovate app も実行ごとに内部で migration をかけている状態です。

validator が要求する migration はこの改名のみで、純粋な alias なので**挙動は変わりません**。

## 検証

`renovate-config-validator` をローカル実行:

- before: `WARN: Config migration necessary` + `INFO: Config validated successfully`
- after: **`INFO: Config validated successfully` のみ / exit 0**

CI の `validate / renovate.json` でも同じものが走ります。

## Notes

- #128（reviewdog version の pin）と同じ `renovate.json` を触りますが、hunk が離れている（`extends` 配列 vs 末尾の `customManagers`）ためどちらの順でマージしても自動マージされます。依存関係はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)