### PR TITLE
fix(build): check out self at github.job_workflow_sha instead of a hardcoded tag

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/build.yml:
+    ignore:
+      # github.job_workflow_sha は実行時に値が入るが、actionlint のプロパティ一覧に
+      # 無いため未定義と報告される。rhysd/actionlint#671 が入ったらこの項目を削除する。
+      - 'property "job_workflow_sha" is not defined in object type'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,9 @@ on:
       GH_FEDERATION_ENDPOINT:
         required: false
 
-env:
-  SELF_VERSION: v6.0.2
-
+# Each job checks out this repository to run ./action-c2a-build{,-win32}.
+# github.job_workflow_sha is the commit SHA of this reusable workflow file, so the
+# actions always come from the same commit as the workflow the caller referenced.
 jobs:
   build_linux32:
     name: Build for linux32
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.job_workflow_sha }}
 
       - name: build
         if: matrix.compiler != 'gcc' || (! inputs.skip_gcc)
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.job_workflow_sha }}
 
       - uses: ./action-c2a-build
         with:
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.job_workflow_sha }}
 
       - uses: ./action-c2a-build-win32
         with:
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.job_workflow_sha }}
 
       - uses: ./action-c2a-build-win32
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,12 @@ on:
       GH_FEDERATION_ENDPOINT:
         required: false
 
-# Each job checks out this repository to run ./action-c2a-build{,-win32}.
-# github.job_workflow_sha is the commit SHA of this reusable workflow file, so the
-# actions always come from the same commit as the workflow the caller referenced.
+# 各ジョブは ./action-c2a-build{,-win32} を使うため、このリポジトリ自身を取得する。
+# github.job_workflow_sha は呼び出されたこのファイル自身のコミット SHA なので、
+# 呼び出す側が指定した版とアクションの版が常に一致する。
+#
+# 下の 4 箇所を actionlint が「job_workflow_sha は未定義」と報告するが、値は実行時に
+# 入る。actionlint のプロパティ一覧に無いだけ (rhysd/actionlint#671)。CI は成功のまま。
 jobs:
   build_linux32:
     name: Build for linux32


### PR DESCRIPTION
## What

`build.yml` が自分自身を取得 (checkout) するときの取得先の指定 (`ref`。ブランチ名・タグ名・コミット SHA のいずれか) を、直接書かれた `SELF_VERSION: v6.0.2` から `github.job_workflow_sha` に変更します。

`build.yml` は、他のリポジトリのワークフローから呼び出して使うワークフローです。`github.job_workflow_sha` には、そうやって呼び出された側のワークフローファイル自身のコミット SHA が入ります。

## Why

`build.yml` は `./action-c2a-build{,-win32}` を実行するために自分のリポジトリを取得しますが、その取得先がタグ直書きです。このため、呼び出す側が `@v6.0.2` / `@main` / 任意のコミット SHA のどれを指定しても、実際に動くアクションは常に `v6.0.2` のものになります。

`v6.0.2` が最新のタグなので、**それ以降にアクション側に入れた変更は、呼び出す側に一度も届いていません**。例えば #125 (gh-federation v4 → v5) は両方のアクションを更新済みですが、呼び出す側は今も v4.0.1 を実行しています。`main` の `SELF_VERSION` も `v6.0.2` のままなので、呼び出す側の指定を `main` に上げても直りません。また `SELF_VERSION` は `env` なので、呼び出す側から差し替えることもできません。

`test-build.yml` が、その PR 自身のアクションの変更を検証できていないのも同じ原因です。

`github.job_workflow_sha` を使えば、タグ直書きが担保しようとしていたこと (ワークフローとアクションを同じコミットに揃える) を保ったまま、呼び出す側が指定した内容に追従します。付け替えできるタグではなくコミット SHA になり、リリースごとに手で書き換える必要もなくなります。

`repository: arkedge/workflows-c2a` を残しているのは、呼び出された側のワークフローの中では `github.repository` が*呼び出す側*のリポジトリを指すためです。

## Verification

この PR の `test-build` の実行ログ:

```
Uses: arkedge/workflows-c2a/.github/workflows/build.yml@refs/pull/130/merge (f171caf2...)
HEAD is now at f171caf Merge 5696af0446... into c40b972d6a...
```

呼び出された `build.yml` のコミットが、そのまま取得対象になっています。取得先に空文字を渡すと `actions/checkout` はエラーにせず既定ブランチを取ってしまうため、取得したコミットが意図した SHA と一致していることが確認点です。

## Note

- actionlint の `property "job_workflow_sha" is not defined` は誤検知です。実行時には値が入っており、actionlint が内部に持つ「`github` に存在するプロパティの一覧」に含まれていないだけです (GitHub のドキュメントが `github` のプロパティ一覧ページに載せておらず、別ページにしか説明がないため)。actionlint 本体への追加提案は rhysd/actionlint#671 です。reviewdog の `fail_level` の既定値が `none` で CI のチェックは成功のままなので、このリポジトリ側に検査除外の設定は入れていません
- `could not parse action metadata` の 2 件は本 PR と無関係な既存の問題で、#131 に切り出しました
