### PR TITLE
bump version to v6.0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ on:
         required: false
 
 env:
-  SELF_VERSION: v6.0.2
+  SELF_VERSION: v6.0.3
 
 jobs:
   build_linux32:


### PR DESCRIPTION
## What

`build.yml` の `SELF_VERSION` を `v6.0.2` → `v6.0.3` に更新します。1 行のみです。

## Why

`build.yml` は `./action-c2a-build{,-win32}` を実行するために自分のリポジトリを `SELF_VERSION` で取得します。この値が `v6.0.2` (2024-07) のまま据え置きになっているため、**それ以降にアクション側へ入れた変更が、呼び出し側に一度も届いていません**。呼び出し側が `@main` や任意のコミットを指定しても、動くアクションは常に `v6.0.2` のものになります。

届いていない変更の例:

- #125 arkedge/gh-federation v4 → v5 (Node 20 → 24) — 呼び出し側は今も `gh-federation@v4.0.1` を実行しています
- actions/checkout v4.1.7 → v7.0.1

`SELF_VERSION` は `env` なので、呼び出し側から差し替えることもできません。

## なぜ patch か

`v6.0.2` → `main` の差分に、**呼び出し側インタフェース (inputs / secrets) の変更はありません**。中身は依存の更新のみです。過去の運用 (入力の追加は major、挙動の修正は patch) に合わせて patch としています。

挙動に影響し得るものとして、Win32 ジョブのランナーが `windows-2022` → `windows-2025` になっています。

## マージ後にお願いしたいこと

`SELF_VERSION` の値は実在するタグを指す必要があるため、**マージ後にこのコミットへ `v6.0.3` のタグを打つ必要があります**。`v6.0.2` のときと同じ流れです (cb46d1d `bump version to v6.0.2` → 同コミットに v6.0.2 タグ)。

タグが打たれるまでの間、`@main` を指定している呼び出し側は `SELF_VERSION: v6.0.3` を解決できず取得に失敗します。タグ付けまで続けてお願いできると安全です。

## 再発防止 (この PR の範囲外)

リリース時の `SELF_VERSION` 更新が漏れると同じ状態に戻ります。「`SELF_VERSION` が最新タグと一致するか」を検査する CI を足すのが確実だと思うので、必要であれば別途 issue / PR を出します。

なお #130 で `github.job_workflow_sha` を使う自動追従を試しましたが、このプロパティは `github` コンテキストには存在せず (OIDC トークンの claim のみ) 常に空文字になるため、成立しないことを実測で確認済みです。詳細は #130 のコメントに残しています。


## CI について

`v6.0.3` のタグが存在するまでは `test-build` の自己取得が `refs/tags/v6.0.3` を解決できず失敗するため、この PR の CI は赤になります (タグ付け後は解消します)。#136 を先に入れると赤になりませんが、この PR のマージに必須ではありません。
