### PR TITLE
fix(build): check out the current commit when this repository tests itself

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ on:
       GH_FEDERATION_ENDPOINT:
         required: false
 
+# 外部から呼ばれたときは SELF_VERSION (リリースごとに更新) のアクションを使う。
+# workflows-c2a 自身のテストでは実行中のコミットを使い、その PR 自身のアクション変更を検証する。
 env:
   SELF_VERSION: v6.0.2
 
@@ -82,7 +84,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.repository == 'arkedge/workflows-c2a' && github.sha || env.SELF_VERSION }}
 
       - name: build
         if: matrix.compiler != 'gcc' || (! inputs.skip_gcc)
@@ -115,7 +117,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.repository == 'arkedge/workflows-c2a' && github.sha || env.SELF_VERSION }}
 
       - uses: ./action-c2a-build
         with:
@@ -137,7 +139,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.repository == 'arkedge/workflows-c2a' && github.sha || env.SELF_VERSION }}
 
       - uses: ./action-c2a-build-win32
         with:
@@ -158,7 +160,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: arkedge/workflows-c2a
-          ref: ${{ env.SELF_VERSION }}
+          ref: ${{ github.repository == 'arkedge/workflows-c2a' && github.sha || env.SELF_VERSION }}
 
       - uses: ./action-c2a-build-win32
         with:


### PR DESCRIPTION
## What

`build.yml` の自己取得の ref を、`workflows-c2a` 自身からの呼び出しのときだけ実行中のコミットにします。外部から呼ばれた場合は `SELF_VERSION` のままで、挙動は変わりません。

```yaml
ref: ${{ github.repository == 'arkedge/workflows-c2a' && github.sha || env.SELF_VERSION }}
```

## Why

1. **リリースのたびに CI が赤くなる** — `SELF_VERSION` を次の版に更新した時点ではまだタグが無いため、`test-build.yml` の自己取得が `refs/tags/vX.Y.Z` を解決できず失敗します (#135 で発生中)
2. **PR が自身のアクション変更を検証できていない** — テスト対象の workflow は PR のものですが、実行されるアクションは `SELF_VERSION` (= 最新タグ) のものになるため、`action-c2a-build{,-win32}` への変更は CI を通っていません

この 2 つはどちらも「自分自身をテストするときに固定タグを見ている」ことが原因なので、そこだけ実行中のコミットに切り替えます。

## 補足

同様の条件分岐は `amd/skills` の再利用ワークフローでも使われています (`if: github.repository != 'amd/skills'`)。

この PR の `test-build` が緑になれば、PR 自身のコミットのアクションでビルドが通ることの確認になります。
