### PR TITLE
fix: SELF_VERSION を gh-federation v5.0.1 を含むコミットに向ける

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,13 @@ on:
         required: false
 
 env:
-  SELF_VERSION: v6.0.2
+  # 本来はリリースタグを指す値。v6.0.2 に据え置かれているため、それ以降にアクション側へ
+  # 入れた修正が呼び出し側に届かない (#135)。中でも gh-federation v4.0.1 の
+  # base64 折り返しバグは、Authorization ヘッダに改行を混ぜて git fetch を
+  # HTTP/2 ストリームごと落とすため、呼び出し側の build が恒常的に赤になる。
+  # v6.0.3 のタグが打たれるまでの暫定として、修正済み (gh-federation v5.0.1) の
+  # main コミットを直接指す。タグ後は SELF_VERSION: v6.0.3 に戻す。
+  SELF_VERSION: c40b972d6a96657d8b2a27bef8d77c2e138690d0
 
 jobs:
   build_linux32:


### PR DESCRIPTION
## What

`build.yml` の `SELF_VERSION` を `v6.0.2` → `c40b972` (main) に変更します。1 行 + コメントです。

**この PR はマージ対象ではありません** (draft)。呼び出し側から参照するためのブランチを残しておくための PR です。本線の修正は #135 (`SELF_VERSION: v6.0.3`) + タグ付けです。

## Why — 呼び出し側の build が恒常的に赤になっている

`SELF_VERSION` が `v6.0.2` に据え置かれているため、`action-c2a-build` が実行する gh-federation は **v4.0.1** のままです。v4.0.1 の該当行:

```bash
TOKEN=$(echo -n "x-access-token:${GH_FEDERATION_ACCESS_TOKEN}" | base64)   # -w0 なし
git config --global "http.…/${repo}.extraheader" "Authorization: Basic ${TOKEN}"
```

GNU `base64` は 76 桁で折り返すため、`extraheader` の値に改行が入ります。改行入りの `Authorization` ヘッダはリクエストとして送出できず、**HTTP/2 ではストリームごと落ちます**。

arkedge/c2a-monaka-mobc の `build` は `federation_repos` を渡すため全 matrix ジョブがこれで落ちています:

```
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +…
fatal: unable to access 'https://github.com/arkedge/c2a-monaka-mobc/':
       HTTP/2 stream 1 was not closed cleanly before end of the underlying stream
→ 3 回リトライして exit 128
```

手元で再現しました:

| extraheader の値 | 結果 |
|---|---|
| 折り返しあり + HTTP/2 | `Failed sending HTTP request` (CI と同じ層の失敗) |
| 折り返しあり + HTTP/1.1 | サーバが **400** を返す |
| 1 行 | 送信成功 (認証段階まで進む) |

同 run 内で `federation_repos` を渡さない `check_encoding` / `check_coding_rule` は、**同じ `actions/checkout` SHA・同じ runner image・同じ fetch コマンドで成功**しています。切り分け要因は gh-federation のバージョンだけです。

なお v4.0.1 は `echo "::add-mask::${TOKEN}"` のマスクも 1 行目にしか効かないため、**App トークン (JWT) が CI ログに平文で残ります**。有効期間 1 時間なので既に失効していますが、`build` が走るたびに 1 時間有効なトークンがリポジトリ read 権限を持つ全員に見える状態です。v5.0.1 に上げれば 1 行になるので同時に解消します。

## 修正内容

v5.0.1 (`b70375c`) では `| base64 | tr -d '\r\n'` で修正済みで、**main の `action-c2a-build` は既に v5.0.1 を pin しています**。届いていないのは `SELF_VERSION` だけなので、その 1 行を main のコミットに向けます。

`v6.0.2..main` の `build.yml` に **inputs / secrets の変更はありません** (checkout v4.1.7 → v7.0.1、win32 の `windows-2022` → `windows-2025`、renovate コメントのみ)。呼び出し側インタフェースは互換です。

## タグではなくコミットハッシュにした理由

- 参照先が動かない。ブランチ名を入れると、そのブランチへの push で全呼び出し側の挙動が黙って変わる
- #135 のように存在しないタグを指さないので、この PR の CI は自己取得に失敗しない

## 呼び出し側

arkedge/c2a-monaka-mobc からは `build.yml@7bd8117156f6b109963b9d436ec3da02165595b6` を pin します。`v6.0.3` のタグが打たれたら、双方をタグ参照に戻して本ブランチは削除します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
